### PR TITLE
ci: strip JaCoCo nr="65535" lines to fix SonarCloud import

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,7 +118,7 @@ sonar {
         property("sonar.tests", mutableListOf("src/test/java", "src/androidTest/java"))
 
         // Optional exclusions (string)
-        property("sonar.exclusions", "**/R.class,**/R$*.class,**/BuildConfig.*,**/Manifest*.*,android/**/*.*")
+        property("sonar.exclusions", "**/R.class,**/R$*.class,**/BuildConfig.*,**/Manifest*.*,android/**/*.*, **/ui/theme/**")
     }
 }
 
@@ -239,6 +239,16 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
             logger.lifecycle("No execution data found — skipping jacocoTestReport.")
         }
         hasData
+    }
+
+    doLast {
+        // New block to modify the XML report after it's generated
+        val reportFile = reports.xml.outputLocation.asFile.get()
+        if (reportFile.exists()) {
+            val content = reportFile.readText()
+            val cleanedContent = content.replace("<line[^>]+nr=\"65535\"[^>]*>".toRegex(), "")
+            reportFile.writeText(cleanedContent)
+        }
     }
 
     // Ensure unit tests ran


### PR DESCRIPTION
Remove bogus <line nr="65535"> entries from JaCoCo XML in doLast so SonarCloud doesn't fail on Compose/Kotlin files. See ED post #308