### PR TITLE
fix: refresh camera screen on switch button

### DIFF
--- a/app/src/main/java/com/android/mygarden/ui/camera/CameraScreen.kt
+++ b/app/src/main/java/com/android/mygarden/ui/camera/CameraScreen.kt
@@ -254,7 +254,13 @@ private fun CameraPreview(controller: LifecycleCameraController, modifier: Modif
           controller.bindToLifecycle(lifeCycleOwner)
         }
       },
-      modifier = modifier.testTag(CameraScreenTestTags.PREVIEW_VIEW))
+      modifier = modifier.testTag(CameraScreenTestTags.PREVIEW_VIEW),
+      update = { view ->
+        if (view.controller !== controller) {
+          view.controller = controller
+          controller.bindToLifecycle(lifeCycleOwner)
+        }
+      })
 }
 
 /**


### PR DESCRIPTION
Fixed the camera screen that was not responding on a camera switching. It nows refresh when the screen in refreshed.