### PR TITLE
refractor/xml replace hardcoded strings and conflict in xml

### DIFF
--- a/app/src/main/java/com/android/mygarden/ui/garden/GardenScreen.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/GardenScreen.kt
@@ -130,14 +130,6 @@ private val AVATAR_SIZE = 40.dp
 private val PLANT_NAME_FONT_SIZE = 20.sp
 private val PLANT_CARD_INFO_FONT_SIZE = 14.sp
 
-// Text values
-private const val MY_GARDEN_TITLE_TEXT = "My Garden"
-private const val EMPTY_GARDEN_MESSAGE_TEXT =
-    "You don't have a plant yet ! Use the button below to add a plant."
-private const val ADD_PLANT_FAB_TEXT = "Add a plant"
-private const val WATER_BUTTON_ICON_DESCRIPTION = "Water plant button"
-private const val SIGN_OUT_BUTTON_DESCRIPTION = "Sign out button"
-
 private fun getOwnedPlantImageDescription(ownedPlant: OwnedPlant): String =
     "Image of a ${ownedPlant.plant.name}"
 
@@ -188,7 +180,7 @@ fun GardenScreen(
               Text(
                   fontWeight = FontWeight.ExtraBold,
                   style = MaterialTheme.typography.titleLarge,
-                  text = MY_GARDEN_TITLE_TEXT)
+                  text = stringResource(R.string.my_garden_title))
             },
             colors =
                 TopAppBarDefaults.topAppBarColors(
@@ -197,7 +189,7 @@ fun GardenScreen(
             navigationIcon = {
               Icon(
                   imageVector = Icons.AutoMirrored.Filled.Logout,
-                  contentDescription = SIGN_OUT_BUTTON_DESCRIPTION,
+                  contentDescription = stringResource(R.string.sign_out_button_description),
                   modifier =
                       modifier
                           .clickable(onClick = onSignOut)
@@ -297,7 +289,7 @@ fun AddPlantFloatingButton(onAddPlant: () -> Unit, modifier: Modifier = Modifier
               painter = painterResource(R.drawable.tree_icon),
               contentDescription = null,
               tint = MaterialTheme.colorScheme.primary)
-          Text(text = ADD_PLANT_FAB_TEXT)
+          Text(text = stringResource(R.string.add_plant_fab_text))
         }
       }
 }
@@ -456,7 +448,7 @@ fun WaterButton(modifier: Modifier = Modifier, color: Color, onButtonPressed: ()
       contentAlignment = Alignment.Center) {
         Icon(
             Icons.Default.WaterDrop,
-            contentDescription = WATER_BUTTON_ICON_DESCRIPTION,
+            contentDescription = stringResource(R.string.water_button_icon_description),
             tint = color,
             modifier = Modifier.size(WATER_BUTTON_DROP_ICON_SIZE))
       }

--- a/app/src/main/res/values/sort_filter_strings.xml
+++ b/app/src/main/res/values/sort_filter_strings.xml
@@ -22,7 +22,4 @@
     <!-- Empty State Messages -->
     <string name="empty_garden_message">You don\'t have a plant yet ! Use the button below to add a plant.</string>
     <string name="empty_filter_message">No plants match the current filters.</string>
-
-    <!-- Water Button -->
-    <string name="water_button_icon_description">Water plant button</string>
 </resources>

--- a/app/src/main/res/values/ui_strings.xml
+++ b/app/src/main/res/values/ui_strings.xml
@@ -46,6 +46,7 @@
 
 
     <!-- Garden Screen -->
+    <string name="my_garden_title">My Garden</string>
     <string name="empty_garden_message_text">You don\'t have a plant yet ! Use the button below to add a plant.</string>
     <string name="add_plant_fab_text">Add a plant</string>
     <string name="water_button_icon_description">Water plant button</string>


### PR DESCRIPTION
## What
Fixed duplicate XML string resource `water_button_icon_description` causing build failure.

## Why
The resource was defined in both `sort_filter_strings.xml` and `ui_strings.xml`, causing a merge conflict that failed the CI build with "Duplicate resources" error.

## How
- Removed duplicate `water_button_icon_description` from `sort_filter_strings.xml`
- Refactored `GardenScreen.kt` to use `stringResource()` instead of hardcoded string constants
- Added missing `my_garden_title` resource to `ui_strings.xml`

## Testing
- Build should pass without "Duplicate resources" error
- Garden screen displays correctly with all strings properly localized
