### PR TITLE
Feature/ci-firestore-indexes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,19 @@ jobs:
           }
           JSON
 
+      # Deploy Firestore indexes to production (only on main branch push)
+      - name: Deploy Firestore Indexes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          if [ -f "firestore.indexes.json" ] && [ -n "$FIREBASE_TOKEN" ]; then
+            echo "Deploying Firestore indexes to production..."
+            firebase deploy --only firestore:indexes --project "${{ steps.firebase_project.outputs.project_id }}" --token "$FIREBASE_TOKEN"
+          else
+            echo "Skipping Firestore indexes deployment (missing firestore.indexes.json or FIREBASE_TOKEN)"
+          fi
+
       - name: Start Firebase emulators
         run: |
           if [ -e "firebase.json" ]; then

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "friend_requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "toUserId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## What
Auto-deploy Firestore indexes via CI
## Why
Fixes `Error listening to incoming requests` error on friend requests queries
## How
- Add `firestore.indexes.json` (composite index: status, toUserId, createdAt)
- Update CI workflow to deploy indexes on main push