### PR TITLE
Fix/new-profile-pseudo-field

### DIFF
--- a/app/src/main/java/com/android/mygarden/ui/profile/ProfileScreenComposables.kt
+++ b/app/src/main/java/com/android/mygarden/ui/profile/ProfileScreenComposables.kt
@@ -147,6 +147,7 @@ private fun ProfileForm(
   var isExperienceExpanded by remember { mutableStateOf(false) }
   var isCountryExpanded by remember { mutableStateOf(false) }
   val countryFocusRequester = remember { FocusRequester() }
+  val pseudoAvailability by profileViewModel.pseudoAvailable.collectAsState()
 
   Column(modifier = modifier, verticalArrangement = Arrangement.SpaceEvenly) {
     // Required fields with validation
@@ -176,13 +177,19 @@ private fun ProfileForm(
         modifier =
             Modifier.fillMaxWidth().testTag(ProfileScreenTestTags.PSEUDO_FIELD).onFocusChanged {
                 state ->
+              // check for pseudo availability if the user quits the text field
               if (!state.isFocused) {
                 profileViewModel.checkAvailabilityNow()
+                // save that the user has entered the pseudo field once at least
+              } else {
+                profileViewModel.hasFocusedPseudoField()
               }
             },
-        isError = profileViewModel.pseudoIsError(),
+        // isError = profileViewModel.pseudoIsError(),
+        isError = !pseudoAvailability,
         supportingText = {
-          if (profileViewModel.pseudoIsError()) {
+          // if (profileViewModel.pseudoIsError()) {
+          if (!pseudoAvailability) {
             Text(
                 text = stringResource(R.string.error_pseudo_taken),
                 color = MaterialTheme.colorScheme.error)


### PR DESCRIPTION
## What ?
This PR fixes UI bugs of the pseudo text field on `NewProfileScreen` & `EditProfileScreen`.
## Why ? 
Before, when coming on the `NewProfileScreen`, because the initial text field was empty, it was displayed as an error text field (because we don't accept empty pseudo in our logic). Now, the text field is initially normal, and each time the user exits the field (looses focus on the text field), the logic is recomputed and the field is potentially displayed as an error (if empty or if the user tries to use another's pseudo).
## How ?
- Updated `ProfileScreenComposables` to ensure text field is showing error when wanted.
- Updated `ProfileViewModel` to handle user interaction with this text field and send error to the UI in correct cases