### PR TITLE
Feature/like garden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,6 @@ jobs:
             ./gradlew connectedAndroidTest --build-cache --stacktrace -Pandroid.testInstrumentationRunnerArguments.notPackage=com.android.mygarden.zEndToEnd -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera
             TEST_EXIT_CODE_0=$?
             echo "Running EndToEndM1..."
-            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM1 --stacktrace
-            TEST_EXIT_CODE_1=$?
             
             echo "Running EndToEndM2..."
             ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM2 --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,27 @@ jobs:
             
             # Run tests and capture exit code
             set +e
-            ./gradlew connectedCheck --build-cache -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera --max-workers=1 --stacktrace
-            TEST_EXIT_CODE=$?
+            
+            # Run each E2E test class separately to ensure complete isolation
+            # This prevents Firebase emulator conflicts between tests
+            echo "Running EndToEndM1..."
+            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM1 --stacktrace
+            TEST_EXIT_CODE_1=$?
+            
+            echo "Running EndToEndM2..."
+            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM2 --stacktrace
+            TEST_EXIT_CODE_2=$?
+            
+            echo "Running EndToEndEpic2..."
+            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndEpic2 --stacktrace
+            TEST_EXIT_CODE_3=$?
+            
+            echo "Running EndToEndM3Achievements..."
+            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM3Achievements --stacktrace
+            TEST_EXIT_CODE_4=$?
+            
+            # Combine exit codes - fail if any test failed
+            TEST_EXIT_CODE=$((TEST_EXIT_CODE_1 + TEST_EXIT_CODE_2 + TEST_EXIT_CODE_3 + TEST_EXIT_CODE_4))
             set -e
             
             # Stop logcat capture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         id: firebase_project
         run: |
           echo "project_id=$(jq -r '.project_info.project_id' app/google-services.json)" >> $GITHUB_OUTPUT
-          
+
       - name: Create firebase.json
         run: |
           cat > firebase.json <<'JSON'
@@ -190,33 +190,8 @@ jobs:
             
             # Run tests and capture exit code
             set +e
-            
-            # Run each E2E test class separately to ensure complete isolation
-            # This prevents Firebase emulator conflicts between tests
-            echo "Running android Test..."
-            ./gradlew connectedAndroidTest --build-cache --stacktrace -Pandroid.testInstrumentationRunnerArguments.notPackage=com.android.mygarden.zEndToEnd -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera
-            TEST_EXIT_CODE_0=$?
-            echo "Running EndToEndM1..."
-            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM1 --stacktrace
-            
-            echo "Running EndToEndM2..."
-            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM2 --stacktrace
-            TEST_EXIT_CODE_2=$?
-            
-            echo "Running EndToEndEpic2..."
-            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndEpic2 --stacktrace
-            TEST_EXIT_CODE_3=$?
-            
-            echo "Running EndToEndM3Achievements..."
-            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM3Achievements --stacktrace
-            TEST_EXIT_CODE_4=$?
-            
-            echo "Running EndToEndM3Community..."
-            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM3Community --stacktrace
-            TEST_EXIT_CODE_5=$?
-            
-            # Combine exit codes - fail if any test failed
-            TEST_EXIT_CODE=$((TEST_EXIT_CODE_0 + TEST_EXIT_CODE_1 + TEST_EXIT_CODE_2 + TEST_EXIT_CODE_3 + TEST_EXIT_CODE_4 +TEST_EXIT_CODE_5))
+            ./gradlew connectedCheck --parallel --build-cache -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera --stacktrace
+            TEST_EXIT_CODE=$?
             set -e
             
             # Stop logcat capture
@@ -256,7 +231,7 @@ jobs:
             
             # Run tests and capture exit code
             set +e
-            ./gradlew connectedCheck --build-cache -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.android.mygarden.utils.RequiresCamera,com.android.mygarden.utils.RequiresFirebaseFunctions --max-workers=1 --stacktrace
+            ./gradlew connectedCheck --parallel --build-cache -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.android.mygarden.utils.RequiresCamera,com.android.mygarden.utils.RequiresFirebaseFunctions --stacktrace
             TEST_EXIT_CODE=$?
             set -e
             

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
             
             # Run tests and capture exit code
             set +e
-            ./gradlew connectedCheck --parallel --build-cache -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera --stacktrace
+            ./gradlew connectedCheck --build-cache -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera --max-workers=1 --stacktrace
             TEST_EXIT_CODE=$?
             set -e
             
@@ -231,7 +231,7 @@ jobs:
             
             # Run tests and capture exit code
             set +e
-            ./gradlew connectedCheck --parallel --build-cache -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.android.mygarden.utils.RequiresCamera,com.android.mygarden.utils.RequiresFirebaseFunctions --stacktrace
+            ./gradlew connectedCheck --build-cache -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.android.mygarden.utils.RequiresCamera,com.android.mygarden.utils.RequiresFirebaseFunctions --max-workers=1 --stacktrace
             TEST_EXIT_CODE=$?
             set -e
             

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
             ./gradlew connectedAndroidTest --build-cache --stacktrace -Pandroid.testInstrumentationRunnerArguments.notPackage=com.android.mygarden.zEndToEnd -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera
             TEST_EXIT_CODE_0=$?
             echo "Running EndToEndM1..."
+            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM1 --stacktrace
             
             echo "Running EndToEndM2..."
             ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM2 --stacktrace
@@ -210,8 +211,12 @@ jobs:
             ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM3Achievements --stacktrace
             TEST_EXIT_CODE_4=$?
             
+            echo "Running EndToEndM3Community..."
+            ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM3Community --stacktrace
+            TEST_EXIT_CODE_5=$?
+            
             # Combine exit codes - fail if any test failed
-            TEST_EXIT_CODE=$((TEST_EXIT_CODE_0 + TEST_EXIT_CODE_1 + TEST_EXIT_CODE_2 + TEST_EXIT_CODE_3 + TEST_EXIT_CODE_4))
+            TEST_EXIT_CODE=$((TEST_EXIT_CODE_0 + TEST_EXIT_CODE_1 + TEST_EXIT_CODE_2 + TEST_EXIT_CODE_3 + TEST_EXIT_CODE_4 +TEST_EXIT_CODE_5))
             set -e
             
             # Stop logcat capture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
             
             # Run each E2E test class separately to ensure complete isolation
             # This prevents Firebase emulator conflicts between tests
+            echo "Running android Test..."
+            ./gradlew connectedAndroidTest --build-cache --stacktrace -Pandroid.testInstrumentationRunnerArguments.notPackage=com.android.mygarden.zEndToEnd -Pandroid.testInstrumentationRunnerArguments.annotation=com.android.mygarden.utils.RequiresCamera
+            TEST_EXIT_CODE_0=$?
             echo "Running EndToEndM1..."
             ./gradlew connectedAndroidTest --build-cache -Pandroid.testInstrumentationRunnerArguments.class=com.android.mygarden.zEndToEnd.EndToEndM1 --stacktrace
             TEST_EXIT_CODE_1=$?
@@ -210,7 +213,7 @@ jobs:
             TEST_EXIT_CODE_4=$?
             
             # Combine exit codes - fail if any test failed
-            TEST_EXIT_CODE=$((TEST_EXIT_CODE_1 + TEST_EXIT_CODE_2 + TEST_EXIT_CODE_3 + TEST_EXIT_CODE_4))
+            TEST_EXIT_CODE=$((TEST_EXIT_CODE_0 + TEST_EXIT_CODE_1 + TEST_EXIT_CODE_2 + TEST_EXIT_CODE_3 + TEST_EXIT_CODE_4))
             set -e
             
             # Stop logcat capture

--- a/app/src/androidTest/java/com/android/mygarden/model/likes/LikesRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/mygarden/model/likes/LikesRepositoryFirestoreTest.kt
@@ -1,0 +1,106 @@
+package com.android.mygarden.model.likes
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.mygarden.model.profile.LikesRepository
+import com.android.mygarden.model.profile.LikesRepositoryFirestore
+import com.android.mygarden.utils.FirebaseEmulator
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LikesRepositoryFirestoreTest {
+
+  private lateinit var db: FirebaseFirestore
+  private lateinit var repo: LikesRepository
+
+  private val targetUid = "TARGET_USER"
+  private val myUid = "LIKER_USER"
+
+  @Before
+  fun setUp() = runTest {
+    FirebaseEmulator.connectFirestore()
+    db = FirebaseFirestore.getInstance()
+    repo = LikesRepositoryFirestore(db)
+
+    // Ensure target user doc exists (required because toggleLike uses tx.update)
+    db.collection("users").document(targetUid).set(mapOf("likesCount" to 0)).await()
+
+    // Ensure no leftover like doc
+    db.collection("users").document(targetUid).collection("likes").document(myUid).delete().await()
+  }
+
+  @After
+  fun tearDown() = runTest {
+    // Clean up
+    db.collection("users").document(targetUid).collection("likes").document(myUid).delete().await()
+    db.collection("users").document(targetUid).delete().await()
+  }
+
+  @Test
+  fun observeLikesCount_emitsCurrentCount() = runBlocking {
+    db.collection("users").document(targetUid).set(mapOf("likesCount" to 7)).await()
+
+    val count = withTimeout(2_000) { repo.observeLikesCount(targetUid).first() }
+
+    assertEquals(7, count)
+  }
+
+  @Test
+  fun observeHasLiked_isFalseThenTrueAfterToggle() = runBlocking {
+    val before = withTimeout(2_000) { repo.observeHasLiked(targetUid, myUid).first() }
+    assertFalse(before)
+
+    repo.toggleLike(targetUid, myUid)
+
+    val after = withTimeout(2_000) { repo.observeHasLiked(targetUid, myUid).first() }
+    assertTrue(after)
+  }
+
+  @Test
+  fun toggleLike_incrementsThenDecrementsLikesCount_andCreatesThenDeletesLikeDoc() = runTest {
+    // Like
+    repo.toggleLike(targetUid, myUid)
+
+    val likesAfterLike =
+        db.collection("users").document(targetUid).get().await().getLong("likesCount") ?: -1L
+    assertEquals(1L, likesAfterLike)
+
+    val likeDocExistsAfterLike =
+        db.collection("users")
+            .document(targetUid)
+            .collection("likes")
+            .document(myUid)
+            .get()
+            .await()
+            .exists()
+    assertTrue(likeDocExistsAfterLike)
+
+    // Unlike (second toggle)
+    repo.toggleLike(targetUid, myUid)
+
+    val likesAfterUnlike =
+        db.collection("users").document(targetUid).get().await().getLong("likesCount") ?: -1L
+    assertEquals(0L, likesAfterUnlike)
+
+    val likeDocExistsAfterUnlike =
+        db.collection("users")
+            .document(targetUid)
+            .collection("likes")
+            .document(myUid)
+            .get()
+            .await()
+            .exists()
+    assertFalse(likeDocExistsAfterUnlike)
+  }
+}

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS2/NavigationS2Tests.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS2/NavigationS2Tests.kt
@@ -14,8 +14,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.mygarden.model.profile.LikesRepositoryProvider
+import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.ui.navigation.AppNavHost
 import com.android.mygarden.ui.navigation.Screen
+import com.android.mygarden.utils.FakeLikesRepository
+import com.android.mygarden.utils.FakeProfileRepository
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -34,6 +38,8 @@ class NavigationS2Tests {
 
   /** Helper to compose AppNavHost once per test with a given start route. */
   private fun setApp(startRoute: String) {
+    LikesRepositoryProvider.repository = FakeLikesRepository()
+    ProfileRepositoryProvider.repository = FakeProfileRepository()
     compose.setContent {
       navController = rememberNavController()
 

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS3/NavigationS3TestsGardenAndEditPlant.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS3/NavigationS3TestsGardenAndEditPlant.kt
@@ -14,6 +14,8 @@ import com.android.mygarden.model.plant.Plant
 import com.android.mygarden.model.plant.PlantHealthStatus
 import com.android.mygarden.model.plant.PlantsRepositoryLocal
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
+import com.android.mygarden.model.profile.LikesRepositoryProvider
+import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.ui.editPlant.DeletePlantPopupTestTags
 import com.android.mygarden.ui.editPlant.EditPlantScreenTestTags
 import com.android.mygarden.ui.garden.GardenScreenTestTags
@@ -21,6 +23,8 @@ import com.android.mygarden.ui.navigation.AppNavHost
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.navigation.Screen
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
+import com.android.mygarden.utils.FakeLikesRepository
+import com.android.mygarden.utils.FakeProfileRepository
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
@@ -58,6 +62,8 @@ class NavigationS3TestsGardenAndEditPlant {
    */
   @Before
   fun setUp() {
+    LikesRepositoryProvider.repository = FakeLikesRepository()
+    ProfileRepositoryProvider.repository = FakeProfileRepository()
     composeTestRule.setContent {
       PlantsRepositoryProvider.repository = PlantsRepositoryLocal()
       val repo = PlantsRepositoryProvider.repository

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditPlantFromPlantInfo.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditPlantFromPlantInfo.kt
@@ -13,16 +13,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.android.mygarden.model.plant.PlantsRepositoryLocal
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
-import com.android.mygarden.model.profile.LikesRepositoryProvider
-import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.ui.editPlant.EditPlantScreenTestTags
 import com.android.mygarden.ui.navigation.AppNavHost
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.navigation.Screen
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.theme.MyGardenTheme
-import com.android.mygarden.utils.FakeLikesRepository
-import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.RequiresCamera
 import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
@@ -56,7 +52,7 @@ class NavigationS4TestsEditPlantFromPlantInfo {
 
   @Before
   fun setUp() {
-    //ProfileRepositoryProvider.repository = FakeProfileRepository()
+    // ProfileRepositoryProvider.repository = FakeProfileRepository()
     PlantsRepositoryProvider.repository = PlantsRepositoryLocal()
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditPlantFromPlantInfo.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditPlantFromPlantInfo.kt
@@ -13,12 +13,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.android.mygarden.model.plant.PlantsRepositoryLocal
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
+import com.android.mygarden.model.profile.LikesRepositoryProvider
+import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.ui.editPlant.EditPlantScreenTestTags
 import com.android.mygarden.ui.navigation.AppNavHost
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.navigation.Screen
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.theme.MyGardenTheme
+import com.android.mygarden.utils.FakeLikesRepository
+import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.RequiresCamera
 import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
@@ -52,6 +56,8 @@ class NavigationS4TestsEditPlantFromPlantInfo {
 
   @Before
   fun setUp() {
+    LikesRepositoryProvider.repository = FakeLikesRepository()
+    ProfileRepositoryProvider.repository = FakeProfileRepository()
     PlantsRepositoryProvider.repository = PlantsRepositoryLocal()
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditPlantFromPlantInfo.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditPlantFromPlantInfo.kt
@@ -56,8 +56,7 @@ class NavigationS4TestsEditPlantFromPlantInfo {
 
   @Before
   fun setUp() {
-    LikesRepositoryProvider.repository = FakeLikesRepository()
-    ProfileRepositoryProvider.repository = FakeProfileRepository()
+    //ProfileRepositoryProvider.repository = FakeProfileRepository()
     PlantsRepositoryProvider.repository = PlantsRepositoryLocal()
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditProfile.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditProfile.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.mygarden.R
 import com.android.mygarden.model.achievements.AchievementsRepositoryProvider
+import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.model.profile.PseudoRepositoryProvider
 import com.android.mygarden.ui.garden.GardenAchievementsParentScreenTestTags
@@ -22,6 +23,7 @@ import com.android.mygarden.ui.navigation.Screen
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
 import com.android.mygarden.ui.theme.MyGardenTheme
 import com.android.mygarden.utils.FakeAchievementsRepository
+import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.FakePseudoRepository
 import org.junit.Before
@@ -46,6 +48,7 @@ class NavigationS4TestsEditProfile {
         AppNavHost(navController = controller, startDestination = Screen.Garden.route)
       }
     }
+    LikesRepositoryProvider.repository = FakeLikesRepository()
     ProfileRepositoryProvider.repository = FakeProfileRepository()
     PseudoRepositoryProvider.repository = FakePseudoRepository()
     AchievementsRepositoryProvider.repository = FakeAchievementsRepository()

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditProfile.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditProfile.kt
@@ -13,8 +13,6 @@ import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.mygarden.R
 import com.android.mygarden.model.achievements.AchievementsRepositoryProvider
-import com.android.mygarden.model.profile.LikesRepositoryProvider
-import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.model.profile.PseudoRepositoryProvider
 import com.android.mygarden.ui.garden.GardenAchievementsParentScreenTestTags
 import com.android.mygarden.ui.navigation.AppNavHost
@@ -23,8 +21,6 @@ import com.android.mygarden.ui.navigation.Screen
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
 import com.android.mygarden.ui.theme.MyGardenTheme
 import com.android.mygarden.utils.FakeAchievementsRepository
-import com.android.mygarden.utils.FakeLikesRepository
-import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.FakePseudoRepository
 import org.junit.Before
 import org.junit.Rule
@@ -48,7 +44,7 @@ class NavigationS4TestsEditProfile {
         AppNavHost(navController = controller, startDestination = Screen.Garden.route)
       }
     }
-    //ProfileRepositoryProvider.repository = FakeProfileRepository()
+    // ProfileRepositoryProvider.repository = FakeProfileRepository()
     PseudoRepositoryProvider.repository = FakePseudoRepository()
     AchievementsRepositoryProvider.repository = FakeAchievementsRepository()
     composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditProfile.kt
+++ b/app/src/androidTest/java/com/android/mygarden/ui/navigation/navS4/NavigationS4TestsEditProfile.kt
@@ -48,8 +48,7 @@ class NavigationS4TestsEditProfile {
         AppNavHost(navController = controller, startDestination = Screen.Garden.route)
       }
     }
-    LikesRepositoryProvider.repository = FakeLikesRepository()
-    ProfileRepositoryProvider.repository = FakeProfileRepository()
+    //ProfileRepositoryProvider.repository = FakeProfileRepository()
     PseudoRepositoryProvider.repository = FakePseudoRepository()
     AchievementsRepositoryProvider.repository = FakeAchievementsRepository()
     composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/com/android/mygarden/utils/FakeLikesRepository.kt
+++ b/app/src/androidTest/java/com/android/mygarden/utils/FakeLikesRepository.kt
@@ -1,0 +1,24 @@
+package com.android.mygarden.utils
+
+import com.android.mygarden.model.profile.LikesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeLikesRepository : LikesRepository {
+  private val counts = mutableMapOf<String, MutableStateFlow<Int>>()
+  private val liked = mutableSetOf<Pair<String, String>>() // (targetUid, myUid)
+
+  override fun observeLikesCount(targetUid: String): Flow<Int> =
+      counts.getOrPut(targetUid) { MutableStateFlow(0) }
+
+  override fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean> =
+      MutableStateFlow(liked.contains(targetUid to myUid))
+
+  override suspend fun toggleLike(targetUid: String, myUid: String) {
+    val key = targetUid to myUid
+    if (liked.add(key)) {
+      val flow = counts.getOrPut(targetUid) { MutableStateFlow(0) }
+      flow.value = flow.value + 1
+    }
+  }
+}

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -145,17 +145,16 @@ class EndToEndEpic2 {
         composeTestRule.waitUntil(TIMEOUT) {
           try {
             composeTestRule
-                .onNodeWithTag(
-                    GardenAchievementsParentScreenTestTags.PSEUDO, useUnmergedTree = true)
+                .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
                 .isDisplayed()
-          } catch (e: AssertionError) {
+          } catch (_: AssertionError) {
             false
           }
         }
 
         // Verify user profile is displayed
         composeTestRule
-            .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO, useUnmergedTree = true)
+            .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
             .assertIsDisplayed()
             .assertTextContains(user_pseudo)
 

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -20,7 +20,6 @@ import com.android.mygarden.MainActivity
 import com.android.mygarden.model.plant.PlantLocation
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
 import com.android.mygarden.model.plant.testTag
-import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.ui.authentication.SignInScreenTestTags
 import com.android.mygarden.ui.camera.CameraScreenTestTags
 import com.android.mygarden.ui.editPlant.DeletePlantPopupTestTags
@@ -30,7 +29,6 @@ import com.android.mygarden.ui.garden.GardenScreenTestTags
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
-import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakePlantRepositoryUtils
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
@@ -92,7 +90,6 @@ class EndToEndEpic2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     Log.d("EndToEndEpic2", "Set up mock repo")
     fakePlantRepoUtils.setUpMockRepo()
-    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)
@@ -126,13 +123,9 @@ class EndToEndEpic2 {
         firebaseUtils.waitForAuthReady()
 
         // === NEW PROFILE SCREEN ===
-        composeTestRule.waitUntil(TIMEOUT) {
-          composeTestRule.onNodeWithTag(ProfileScreenTestTags.SCREEN).isDisplayed()
-        }
+        composeTestRule.onNodeWithTag(ProfileScreenTestTags.SCREEN).assertIsDisplayed()
         composeTestRule.onNodeWithTag(ProfileScreenTestTags.FIRST_NAME_FIELD).performTextInput(john)
-        composeTestRule.waitUntil(TIMEOUT) {
-          composeTestRule.onNodeWithTag(ProfileScreenTestTags.LAST_NAME_FIELD).isDisplayed()
-        }
+        composeTestRule.onNodeWithTag(ProfileScreenTestTags.LAST_NAME_FIELD).performTextInput(doe)
         composeTestRule
             .onNodeWithTag(ProfileScreenTestTags.PSEUDO_FIELD)
             .performTextInput(user_pseudo)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -141,6 +141,7 @@ class EndToEndEpic2 {
         // === CRITICAL FIX: Visit Garden screen first to ensure UserProfile is properly loaded ===
         // This ensures GardenViewModel initializes with the newly created user profile
         composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
+        composeTestRule.waitForIdle()
         composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE")
         // Wait for Garden screen to fully load with user profile
         composeTestRule.waitUntil(TIMEOUT) {
@@ -210,7 +211,19 @@ class EndToEndEpic2 {
               .isDisplayed()
         }
 
+        composeTestRule.waitForIdle()
+
         // Check that the pseudo and the avatar are displayed
+        composeTestRule.waitUntil(TIMEOUT) {
+          try {
+            composeTestRule
+                .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
+                .isDisplayed()
+            true
+          } catch (_: AssertionError) {
+            false
+          }
+        }
         composeTestRule
             .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
             .assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -20,6 +20,8 @@ import com.android.mygarden.MainActivity
 import com.android.mygarden.model.plant.PlantLocation
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
 import com.android.mygarden.model.plant.testTag
+import com.android.mygarden.model.profile.LikesRepositoryProvider
+import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.ui.authentication.SignInScreenTestTags
 import com.android.mygarden.ui.camera.CameraScreenTestTags
 import com.android.mygarden.ui.editPlant.DeletePlantPopupTestTags
@@ -29,7 +31,9 @@ import com.android.mygarden.ui.garden.GardenScreenTestTags
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
+import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakePlantRepositoryUtils
+import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
 import com.android.mygarden.utils.RequiresCamera
@@ -90,6 +94,7 @@ class EndToEndEpic2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     Log.d("EndToEndEpic2", "Set up mock repo")
     fakePlantRepoUtils.setUpMockRepo()
+      LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -144,18 +144,18 @@ class EndToEndEpic2 {
         // This ensures GardenViewModel initializes with the newly created user profile
         composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
 
-          composeTestRule.waitForIdle()
+        composeTestRule.waitForIdle()
         // Wait for Garden screen to fully load with user profile
-          composeTestRule.waitUntil(TIMEOUT) {
-              try {
-                  composeTestRule
-                      .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
-                      .assertTextContains(user_pseudo)
-                  true
-              } catch (_: AssertionError) {
-                  false
-              }
+        composeTestRule.waitUntil(TIMEOUT) {
+          try {
+            composeTestRule
+                .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
+                .assertTextContains(user_pseudo)
+            true
+          } catch (_: AssertionError) {
+            false
           }
+        }
 
         // Verify user profile is displayed
         composeTestRule

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -147,7 +147,6 @@ class EndToEndEpic2 {
             composeTestRule
                 .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
                 .isDisplayed()
-            true
           } catch (e: AssertionError) {
             false
           }
@@ -155,7 +154,7 @@ class EndToEndEpic2 {
 
         // Verify user profile is displayed
         composeTestRule
-            .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
+            .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO, useUnmergedTree = true)
             .assertIsDisplayed()
             .assertTextContains(user_pseudo)
 

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -21,6 +21,7 @@ import com.android.mygarden.MainActivity
 import com.android.mygarden.model.plant.PlantLocation
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
 import com.android.mygarden.model.plant.testTag
+import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.ui.authentication.SignInScreenTestTags
 import com.android.mygarden.ui.camera.CameraScreenTestTags
 import com.android.mygarden.ui.editPlant.DeletePlantPopupTestTags
@@ -30,6 +31,7 @@ import com.android.mygarden.ui.garden.GardenScreenTestTags
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
+import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakePlantRepositoryUtils
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
@@ -91,6 +93,7 @@ class EndToEndEpic2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     Log.d("EndToEndEpic2", "Set up mock repo")
     fakePlantRepoUtils.setUpMockRepo()
+    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -36,7 +36,6 @@ import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
 import com.android.mygarden.utils.RequiresCamera
 import com.android.mygarden.utils.TestPlants
-import java.lang.Thread.sleep
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -145,17 +144,18 @@ class EndToEndEpic2 {
         // This ensures GardenViewModel initializes with the newly created user profile
         composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
 
+          composeTestRule.waitForIdle()
         // Wait for Garden screen to fully load with user profile
-        composeTestRule.waitUntil(TIMEOUT) {
-          try {
-            composeTestRule
-                .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
-                .isDisplayed()
-            true
-          } catch (e: AssertionError) {
-            false
+          composeTestRule.waitUntil(TIMEOUT) {
+              try {
+                  composeTestRule
+                      .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
+                      .assertTextContains(user_pseudo)
+                  true
+              } catch (_: AssertionError) {
+                  false
+              }
           }
-        }
 
         // Verify user profile is displayed
         composeTestRule
@@ -165,7 +165,7 @@ class EndToEndEpic2 {
 
         // Now navigate to camera
         composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_BUTTON).performClick()
-        sleep(15000)
+
         // === CAMERA SCREEN ===
         composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_SCREEN).assertIsDisplayed()
 

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.printToLog
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
@@ -140,7 +141,7 @@ class EndToEndEpic2 {
         // === CRITICAL FIX: Visit Garden screen first to ensure UserProfile is properly loaded ===
         // This ensures GardenViewModel initializes with the newly created user profile
         composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
-
+        composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE")
         // Wait for Garden screen to fully load with user profile
         composeTestRule.waitUntil(TIMEOUT) {
           try {

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -36,6 +36,7 @@ import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
 import com.android.mygarden.utils.RequiresCamera
 import com.android.mygarden.utils.TestPlants
+import java.lang.Thread.sleep
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -164,7 +165,7 @@ class EndToEndEpic2 {
 
         // Now navigate to camera
         composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_BUTTON).performClick()
-
+        sleep(15000)
         // === CAMERA SCREEN ===
         composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_SCREEN).assertIsDisplayed()
 

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -21,7 +21,6 @@ import com.android.mygarden.model.plant.PlantLocation
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
 import com.android.mygarden.model.plant.testTag
 import com.android.mygarden.model.profile.LikesRepositoryProvider
-import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.ui.authentication.SignInScreenTestTags
 import com.android.mygarden.ui.camera.CameraScreenTestTags
 import com.android.mygarden.ui.editPlant.DeletePlantPopupTestTags
@@ -33,7 +32,6 @@ import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
 import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakePlantRepositoryUtils
-import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
 import com.android.mygarden.utils.RequiresCamera
@@ -94,7 +92,7 @@ class EndToEndEpic2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     Log.d("EndToEndEpic2", "Set up mock repo")
     fakePlantRepoUtils.setUpMockRepo()
-      LikesRepositoryProvider.repository = FakeLikesRepository()
+    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -148,11 +148,12 @@ class EndToEndEpic2 {
             composeTestRule
                 .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
                 .isDisplayed()
+            true
           } catch (_: AssertionError) {
             false
           }
         }
-        composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE2")
+        composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE")
 
         // Verify user profile is displayed
         composeTestRule

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -126,9 +126,13 @@ class EndToEndEpic2 {
         firebaseUtils.waitForAuthReady()
 
         // === NEW PROFILE SCREEN ===
-        composeTestRule.onNodeWithTag(ProfileScreenTestTags.SCREEN).assertIsDisplayed()
+        composeTestRule.waitUntil(TIMEOUT) {
+          composeTestRule.onNodeWithTag(ProfileScreenTestTags.SCREEN).isDisplayed()
+        }
         composeTestRule.onNodeWithTag(ProfileScreenTestTags.FIRST_NAME_FIELD).performTextInput(john)
-        composeTestRule.onNodeWithTag(ProfileScreenTestTags.LAST_NAME_FIELD).performTextInput(doe)
+        composeTestRule.waitUntil(TIMEOUT) {
+          composeTestRule.onNodeWithTag(ProfileScreenTestTags.LAST_NAME_FIELD).isDisplayed()
+        }
         composeTestRule
             .onNodeWithTag(ProfileScreenTestTags.PSEUDO_FIELD)
             .performTextInput(user_pseudo)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -145,7 +145,8 @@ class EndToEndEpic2 {
         composeTestRule.waitUntil(TIMEOUT) {
           try {
             composeTestRule
-                .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
+                .onNodeWithTag(
+                    GardenAchievementsParentScreenTestTags.PSEUDO, useUnmergedTree = true)
                 .isDisplayed()
           } catch (e: AssertionError) {
             false

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -152,6 +152,7 @@ class EndToEndEpic2 {
             false
           }
         }
+        composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE2")
 
         // Verify user profile is displayed
         composeTestRule

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndEpic2.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.test.printToLog
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
@@ -86,6 +85,7 @@ class EndToEndEpic2 {
 
   @Before
   fun setUp() = runTest {
+    LikesRepositoryProvider.repository = FakeLikesRepository()
     // Set up any necessary configurations or states before each test
     Log.d("EndToEndEpic2", "setUpEntry")
     firebaseUtils.initialize()
@@ -93,7 +93,6 @@ class EndToEndEpic2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     Log.d("EndToEndEpic2", "Set up mock repo")
     fakePlantRepoUtils.setUpMockRepo()
-    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)
@@ -144,8 +143,7 @@ class EndToEndEpic2 {
         // === CRITICAL FIX: Visit Garden screen first to ensure UserProfile is properly loaded ===
         // This ensures GardenViewModel initializes with the newly created user profile
         composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE")
+
         // Wait for Garden screen to fully load with user profile
         composeTestRule.waitUntil(TIMEOUT) {
           try {
@@ -153,11 +151,10 @@ class EndToEndEpic2 {
                 .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
                 .isDisplayed()
             true
-          } catch (_: AssertionError) {
+          } catch (e: AssertionError) {
             false
           }
         }
-        composeTestRule.onRoot(useUnmergedTree = true).printToLog("COMPOSE_TREE")
 
         // Verify user profile is displayed
         composeTestRule
@@ -214,19 +211,7 @@ class EndToEndEpic2 {
               .isDisplayed()
         }
 
-        composeTestRule.waitForIdle()
-
         // Check that the pseudo and the avatar are displayed
-        composeTestRule.waitUntil(TIMEOUT) {
-          try {
-            composeTestRule
-                .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
-                .isDisplayed()
-            true
-          } catch (_: AssertionError) {
-            false
-          }
-        }
         composeTestRule
             .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
             .assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM1.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM1.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
@@ -31,6 +30,7 @@ import com.android.mygarden.utils.FakePlantRepositoryUtils
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
 import com.android.mygarden.utils.RequiresCamera
+import java.lang.Thread.sleep
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -125,12 +125,7 @@ class EndToEndM1 {
         .performTextInput("Switzerland")
     composeTestRule.onNodeWithTag(ProfileScreenTestTags.SAVE_BUTTON).performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(TIMEOUT) {
-      composeTestRule
-          .onAllNodesWithTag(NavigationTestTags.CAMERA_SCREEN)
-          .fetchSemanticsNodes()
-          .isNotEmpty()
-    }
+    sleep(15000)
     composeTestRule.waitUntil(TIMEOUT) {
       composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_BUTTON).isDisplayed()
     }

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM1.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM1.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
@@ -124,6 +125,12 @@ class EndToEndM1 {
         .performTextInput("Switzerland")
     composeTestRule.onNodeWithTag(ProfileScreenTestTags.SAVE_BUTTON).performClick()
     composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(TIMEOUT) {
+      composeTestRule
+          .onAllNodesWithTag(NavigationTestTags.CAMERA_SCREEN)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
     composeTestRule.waitUntil(TIMEOUT) {
       composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_BUTTON).isDisplayed()
     }

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM1.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM1.kt
@@ -30,7 +30,6 @@ import com.android.mygarden.utils.FakePlantRepositoryUtils
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
 import com.android.mygarden.utils.RequiresCamera
-import java.lang.Thread.sleep
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -125,7 +124,6 @@ class EndToEndM1 {
         .performTextInput("Switzerland")
     composeTestRule.onNodeWithTag(ProfileScreenTestTags.SAVE_BUTTON).performClick()
     composeTestRule.waitForIdle()
-    sleep(15000)
     composeTestRule.waitUntil(TIMEOUT) {
       composeTestRule.onNodeWithTag(NavigationTestTags.CAMERA_BUTTON).isDisplayed()
     }

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM2.kt
@@ -125,11 +125,18 @@ class EndToEndM2 {
 
     // goto MyGarden
     composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
+    composeTestRule.waitForIdle()
     composeTestRule
         .onNodeWithTag(NavigationTestTags.GARDEN_ACHIEVEMENTS_PARENT_SCREEN)
         .assertIsDisplayed()
+    composeTestRule.waitForIdle()
     composeTestRule.waitUntil(TIMEOUT) {
-      composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
+      try {
+        composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
+        true
+      } catch (e: AssertionError) {
+        false
+      }
     }
     composeTestRule
         .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
@@ -160,8 +167,14 @@ class EndToEndM2 {
           .onNodeWithTag(NavigationTestTags.GARDEN_ACHIEVEMENTS_PARENT_SCREEN)
           .isDisplayed()
     }
+    composeTestRule.waitForIdle()
     composeTestRule.waitUntil(TIMEOUT) {
-      composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
+      try {
+        composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
+        true
+      } catch (e: AssertionError) {
+        false
+      }
     }
     composeTestRule
         .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM2.kt
@@ -76,6 +76,7 @@ class EndToEndM2 {
 
   @Before
   fun setUp() = runTest {
+    LikesRepositoryProvider.repository = FakeLikesRepository()
     // Set up any necessary configurations or states before each test
     Log.d("EndToEndM2", "setUpEntry")
     firebaseUtils.initialize()
@@ -83,7 +84,6 @@ class EndToEndM2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     fakePlantRepoUtils.setUpMockRepo()
     Log.d("EndToEndM2", "Set up mock repo")
-    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)
@@ -128,18 +128,11 @@ class EndToEndM2 {
 
     // goto MyGarden
     composeTestRule.onNodeWithTag(NavigationTestTags.GARDEN_BUTTON).performClick()
-    composeTestRule.waitForIdle()
     composeTestRule
         .onNodeWithTag(NavigationTestTags.GARDEN_ACHIEVEMENTS_PARENT_SCREEN)
         .assertIsDisplayed()
-    composeTestRule.waitForIdle()
     composeTestRule.waitUntil(TIMEOUT) {
-      try {
-        composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
-        true
-      } catch (e: AssertionError) {
-        false
-      }
+      composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
     }
     composeTestRule
         .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)
@@ -170,14 +163,8 @@ class EndToEndM2 {
           .onNodeWithTag(NavigationTestTags.GARDEN_ACHIEVEMENTS_PARENT_SCREEN)
           .isDisplayed()
     }
-    composeTestRule.waitForIdle()
     composeTestRule.waitUntil(TIMEOUT) {
-      try {
-        composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
-        true
-      } catch (e: AssertionError) {
-        false
-      }
+      composeTestRule.onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO).isDisplayed()
     }
     composeTestRule
         .onNodeWithTag(GardenAchievementsParentScreenTestTags.PSEUDO)

--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM2.kt
@@ -19,6 +19,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.android.mygarden.MainActivity
 import com.android.mygarden.model.plant.Plant
 import com.android.mygarden.model.plant.PlantLocation
+import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.ui.authentication.SignInScreenTestTags
 import com.android.mygarden.ui.camera.CameraScreenTestTags
 import com.android.mygarden.ui.editPlant.EditPlantScreenTestTags
@@ -28,6 +29,7 @@ import com.android.mygarden.ui.garden.GardenTab
 import com.android.mygarden.ui.navigation.NavigationTestTags
 import com.android.mygarden.ui.plantinfos.PlantInfoScreenTestTags
 import com.android.mygarden.ui.profile.ProfileScreenTestTags
+import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakePlantRepositoryUtils
 import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.PlantRepositoryType
@@ -81,6 +83,7 @@ class EndToEndM2 {
     fakePlantRepoUtils.mockIdentifyPlant(mockPlant)
     fakePlantRepoUtils.setUpMockRepo()
     Log.d("EndToEndM2", "Set up mock repo")
+    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Now launch the activity AFTER Firebase is cleaned up
     scenario = ActivityScenario.launch(MainActivity::class.java)

--- a/app/src/main/java/com/android/mygarden/model/profile/LikesRepository.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/LikesRepository.kt
@@ -1,0 +1,45 @@
+package com.android.mygarden.model.profile
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository responsible for handling likes on user gardens (profiles).
+ *
+ * A like is represented by a document at:
+ * users/{targetUid}/likes/{likerUid}
+ *
+ * The document existence prevents double-like, while a counter
+ * (likesCount) stored on the target profile allows fast display.
+ */
+interface LikesRepository {
+
+    /**
+     * Observes the number of likes of the target user's garden.
+     *
+     * @param targetUid UID of the garden owner
+     * @return a flow emitting the current likes count
+     */
+    fun observeLikesCount(targetUid: String): Flow<Int>
+
+    /**
+     * Observes whether the current user has already liked the target garden.
+     *
+     * @param targetUid UID of the garden owner
+     * @param myUid UID of the current user
+     * @return a flow emitting true if already liked, false otherwise
+     */
+    fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean>
+
+    /**
+     * Toggles a like on the target garden.
+     *
+     * If the garden is not liked yet, a like is added and the counter incremented.
+     * If already liked, the like is removed and the counter decremented.
+     *
+     * This operation is executed atomically using a Firestore transaction.
+     *
+     * @param targetUid UID of the garden owner
+     * @param myUid UID of the current user
+     */
+    suspend fun toggleLike(targetUid: String, myUid: String)
+}

--- a/app/src/main/java/com/android/mygarden/model/profile/LikesRepository.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/LikesRepository.kt
@@ -5,41 +5,40 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Repository responsible for handling likes on user gardens (profiles).
  *
- * A like is represented by a document at:
- * users/{targetUid}/likes/{likerUid}
+ * A like is represented by a document at: users/{targetUid}/likes/{likerUid}
  *
- * The document existence prevents double-like, while a counter
- * (likesCount) stored on the target profile allows fast display.
+ * The document existence prevents double-like, while a counter (likesCount) stored on the target
+ * profile allows fast display.
  */
 interface LikesRepository {
 
-    /**
-     * Observes the number of likes of the target user's garden.
-     *
-     * @param targetUid UID of the garden owner
-     * @return a flow emitting the current likes count
-     */
-    fun observeLikesCount(targetUid: String): Flow<Int>
+  /**
+   * Observes the number of likes of the target user's garden.
+   *
+   * @param targetUid UID of the garden owner
+   * @return a flow emitting the current likes count
+   */
+  fun observeLikesCount(targetUid: String): Flow<Int>
 
-    /**
-     * Observes whether the current user has already liked the target garden.
-     *
-     * @param targetUid UID of the garden owner
-     * @param myUid UID of the current user
-     * @return a flow emitting true if already liked, false otherwise
-     */
-    fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean>
+  /**
+   * Observes whether the current user has already liked the target garden.
+   *
+   * @param targetUid UID of the garden owner
+   * @param myUid UID of the current user
+   * @return a flow emitting true if already liked, false otherwise
+   */
+  fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean>
 
-    /**
-     * Toggles a like on the target garden.
-     *
-     * If the garden is not liked yet, a like is added and the counter incremented.
-     * If already liked, the like is removed and the counter decremented.
-     *
-     * This operation is executed atomically using a Firestore transaction.
-     *
-     * @param targetUid UID of the garden owner
-     * @param myUid UID of the current user
-     */
-    suspend fun toggleLike(targetUid: String, myUid: String)
+  /**
+   * Toggles a like on the target garden.
+   *
+   * If the garden is not liked yet, a like is added and the counter incremented. If already liked,
+   * the like is removed and the counter decremented.
+   *
+   * This operation is executed atomically using a Firestore transaction.
+   *
+   * @param targetUid UID of the garden owner
+   * @param myUid UID of the current user
+   */
+  suspend fun toggleLike(targetUid: String, myUid: String)
 }

--- a/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryFirestore.kt
@@ -7,67 +7,63 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 
-
 /**
  * Firestore implementation of [LikesRepository].
  *
- * Likes are stored as documents whose ID is the UID of the liker,
- * ensuring that a user can like a given garden only once.
+ * Likes are stored as documents whose ID is the UID of the liker, ensuring that a user can like a
+ * given garden only once.
  */
-class LikesRepositoryFirestore(
-    private val db: FirebaseFirestore
-) : LikesRepository {
+class LikesRepositoryFirestore(private val db: FirebaseFirestore) : LikesRepository {
 
-    private fun userDoc(uid: String) =
-        db.collection("users").document(uid)
+  private fun userDoc(uid: String) = db.collection("users").document(uid)
 
-    private fun likeDoc(targetUid: String, myUid: String) =
-        userDoc(targetUid).collection("likes").document(myUid)
+  private fun likeDoc(targetUid: String, myUid: String) =
+      userDoc(targetUid).collection("likes").document(myUid)
 
-    override fun observeLikesCount(targetUid: String): Flow<Int> = callbackFlow {
-        val reg = userDoc(targetUid).addSnapshotListener { snap, err ->
-            if (err != null) {
-                close(err)
-                return@addSnapshotListener
-            }
-            trySend(snap?.getLong("likesCount")?.toInt() ?: 0)
+  override fun observeLikesCount(targetUid: String): Flow<Int> = callbackFlow {
+    val reg =
+        userDoc(targetUid).addSnapshotListener { snap, err ->
+          if (err != null) {
+            close(err)
+            return@addSnapshotListener
+          }
+          trySend(snap?.getLong("likesCount")?.toInt() ?: 0)
         }
-        awaitClose { reg.remove() }
-    }
+    awaitClose { reg.remove() }
+  }
 
-    override fun observeHasLiked(
-        targetUid: String,
-        myUid: String
-    ): Flow<Boolean> = callbackFlow {
-        val reg = likeDoc(targetUid, myUid).addSnapshotListener { snap, err ->
-            if (err != null) {
-                close(err)
-                return@addSnapshotListener
-            }
-            trySend(snap?.exists() == true)
+  override fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean> = callbackFlow {
+    val reg =
+        likeDoc(targetUid, myUid).addSnapshotListener { snap, err ->
+          if (err != null) {
+            close(err)
+            return@addSnapshotListener
+          }
+          trySend(snap?.exists() == true)
         }
-        awaitClose { reg.remove() }
-    }
+    awaitClose { reg.remove() }
+  }
 
-    override suspend fun toggleLike(targetUid: String, myUid: String) {
-        if (targetUid == myUid) return
+  override suspend fun toggleLike(targetUid: String, myUid: String) {
+    if (targetUid == myUid) return
 
-        val targetRef = userDoc(targetUid)
-        val likeRef = likeDoc(targetUid, myUid)
+    val targetRef = userDoc(targetUid)
+    val likeRef = likeDoc(targetUid, myUid)
 
-        db.runTransaction { tx ->
-            val likeSnap = tx.get(likeRef)
-            val profileSnap = tx.get(targetRef)
-            val current = profileSnap.getLong("likesCount") ?: 0L
+    db.runTransaction { tx ->
+          val likeSnap = tx.get(likeRef)
+          val profileSnap = tx.get(targetRef)
+          val current = profileSnap.getLong("likesCount") ?: 0L
 
-            if (!likeSnap.exists()) {
-                tx.set(likeRef, mapOf("createdAt" to FieldValue.serverTimestamp()))
-                tx.update(targetRef, "likesCount", current + 1)
-            } else {
-                tx.delete(likeRef)
-                tx.update(targetRef, "likesCount", maxOf(0L, current - 1))
-            }
-            null
-        }.await()
-    }
+          if (!likeSnap.exists()) {
+            tx.set(likeRef, mapOf("createdAt" to FieldValue.serverTimestamp()))
+            tx.update(targetRef, "likesCount", current + 1)
+          } else {
+            tx.delete(likeRef)
+            tx.update(targetRef, "likesCount", maxOf(0L, current - 1))
+          }
+          null
+        }
+        .await()
+  }
 }

--- a/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryFirestore.kt
@@ -1,0 +1,73 @@
+package com.android.mygarden.model.profile
+
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+
+
+/**
+ * Firestore implementation of [LikesRepository].
+ *
+ * Likes are stored as documents whose ID is the UID of the liker,
+ * ensuring that a user can like a given garden only once.
+ */
+class LikesRepositoryFirestore(
+    private val db: FirebaseFirestore
+) : LikesRepository {
+
+    private fun userDoc(uid: String) =
+        db.collection("users").document(uid)
+
+    private fun likeDoc(targetUid: String, myUid: String) =
+        userDoc(targetUid).collection("likes").document(myUid)
+
+    override fun observeLikesCount(targetUid: String): Flow<Int> = callbackFlow {
+        val reg = userDoc(targetUid).addSnapshotListener { snap, err ->
+            if (err != null) {
+                close(err)
+                return@addSnapshotListener
+            }
+            trySend(snap?.getLong("likesCount")?.toInt() ?: 0)
+        }
+        awaitClose { reg.remove() }
+    }
+
+    override fun observeHasLiked(
+        targetUid: String,
+        myUid: String
+    ): Flow<Boolean> = callbackFlow {
+        val reg = likeDoc(targetUid, myUid).addSnapshotListener { snap, err ->
+            if (err != null) {
+                close(err)
+                return@addSnapshotListener
+            }
+            trySend(snap?.exists() == true)
+        }
+        awaitClose { reg.remove() }
+    }
+
+    override suspend fun toggleLike(targetUid: String, myUid: String) {
+        if (targetUid == myUid) return
+
+        val targetRef = userDoc(targetUid)
+        val likeRef = likeDoc(targetUid, myUid)
+
+        db.runTransaction { tx ->
+            val likeSnap = tx.get(likeRef)
+            val profileSnap = tx.get(targetRef)
+            val current = profileSnap.getLong("likesCount") ?: 0L
+
+            if (!likeSnap.exists()) {
+                tx.set(likeRef, mapOf("createdAt" to FieldValue.serverTimestamp()))
+                tx.update(targetRef, "likesCount", current + 1)
+            } else {
+                tx.delete(likeRef)
+                tx.update(targetRef, "likesCount", maxOf(0L, current - 1))
+            }
+            null
+        }.await()
+    }
+}

--- a/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryProvider.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryProvider.kt
@@ -3,23 +3,20 @@ package com.android.mygarden.model.profile
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
 
-
 // Singleton-style provider for the LikesRepository.
 // Basically, this gives easy access to one shared instance across the app.
 object LikesRepositoryProvider {
-    // Lazily create the Firestore-backed repository when first used.
-    private val _repository: LikesRepository by lazy {
-        LikesRepositoryFirestore(Firebase.firestore)
+  // Lazily create the Firestore-backed repository when first used.
+  private val _repository: LikesRepository by lazy { LikesRepositoryFirestore(Firebase.firestore) }
+
+  // Repository that we can override in tests
+  private var _overrideRepositoryTest: LikesRepository? = null
+
+  // Public reference to the current repository.
+  // Can be swapped out in tests if needed (e.g., replaced with a fake repo).
+  var repository: LikesRepository
+    get() = _overrideRepositoryTest ?: _repository
+    set(value) {
+      _overrideRepositoryTest = value
     }
-
-    // Repository that we can override in tests
-    private var _overrideRepositoryTest: LikesRepository? = null
-
-    // Public reference to the current repository.
-    // Can be swapped out in tests if needed (e.g., replaced with a fake repo).
-    var repository: LikesRepository
-        get() = _overrideRepositoryTest ?: _repository
-        set(value) {
-            _overrideRepositoryTest = value
-        }
 }

--- a/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryProvider.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/LikesRepositoryProvider.kt
@@ -1,0 +1,25 @@
+package com.android.mygarden.model.profile
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+
+
+// Singleton-style provider for the LikesRepository.
+// Basically, this gives easy access to one shared instance across the app.
+object LikesRepositoryProvider {
+    // Lazily create the Firestore-backed repository when first used.
+    private val _repository: LikesRepository by lazy {
+        LikesRepositoryFirestore(Firebase.firestore)
+    }
+
+    // Repository that we can override in tests
+    private var _overrideRepositoryTest: LikesRepository? = null
+
+    // Public reference to the current repository.
+    // Can be swapped out in tests if needed (e.g., replaced with a fake repo).
+    var repository: LikesRepository
+        get() = _overrideRepositoryTest ?: _repository
+        set(value) {
+            _overrideRepositoryTest = value
+        }
+}

--- a/app/src/main/java/com/android/mygarden/model/profile/Profile.kt
+++ b/app/src/main/java/com/android/mygarden/model/profile/Profile.kt
@@ -16,6 +16,7 @@ import com.android.mygarden.ui.profile.Avatar
  * @param country The user's country of residence
  * @param hasSignedIn The user is signed in
  * @param avatar the user's avatar
+ * @param likesCount the number of likes the garden has
  */
 data class Profile(
     val firstName: String = "",
@@ -25,7 +26,8 @@ data class Profile(
     val favoritePlant: String = "",
     val country: String = "",
     val hasSignedIn: Boolean = false,
-    val avatar: Avatar = Avatar.A1
+    val avatar: Avatar = Avatar.A1,
+    val likesCount: Int = 0,
 )
 /**
  * Represents the different levels of gardening experience and skill.

--- a/app/src/main/java/com/android/mygarden/ui/addFriend/AddFriendViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/addFriend/AddFriendViewModel.kt
@@ -152,6 +152,7 @@ class AddFriendViewModel(
    */
   fun onAsk(userId: String, onError: () -> Unit, onSuccess: () -> Unit) {
 
+
     viewModelScope.launch {
       val currentRelation = _uiState.value.relations[userId] ?: FriendRelation.ADD
       _uiState.value =

--- a/app/src/main/java/com/android/mygarden/ui/addFriend/AddFriendViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/addFriend/AddFriendViewModel.kt
@@ -152,7 +152,6 @@ class AddFriendViewModel(
    */
   fun onAsk(userId: String, onError: () -> Unit, onSuccess: () -> Unit) {
 
-
     viewModelScope.launch {
       val currentRelation = _uiState.value.relations[userId] ?: FriendRelation.ADD
       _uiState.value =

--- a/app/src/main/java/com/android/mygarden/ui/addFriend/AddFriendViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/addFriend/AddFriendViewModel.kt
@@ -157,8 +157,10 @@ class AddFriendViewModel(
           _uiState.value.let { state ->
             if (state.relations.get(userId) == FriendRelation.ADDBACK) {
               state.copy(relations = state.relations + (userId to FriendRelation.ADDED))
-            } else {
+            } else if (state.relations.get(userId) == FriendRelation.ADD) {
               state.copy(relations = state.relations + (userId to FriendRelation.PENDING))
+            } else {
+              return@launch
             }
           }
       try {

--- a/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
@@ -81,41 +81,36 @@ class GardenViewModel(
    * It also updates the likeCount and hasLiked according to the like logic
    */
   init {
-    // Skip Firebase-related initialization during E2E tests to avoid early Firebase initialization
-    val isE2ETest = System.getProperty("mygarden.e2e") == "true"
+    refreshUIState()
 
-    if (!isE2ETest) {
-      refreshUIState()
+    // Likes: observe count for the displayed garden (own or friend's)
+    viewModelScope.launch {
+      val targetUid = friendId ?: profileRepo.getCurrentUserId()
+      if (targetUid != null) {
+        likesRepo.observeLikesCount(targetUid).collect { count ->
+          _uiState.value = _uiState.value.copy(likesCount = count)
+        }
+      }
+    }
 
-      // Likes: observe count for the displayed garden (own or friend's)
+    // Likes: only relevant when viewing a friend's garden
+    if (friendId != null) {
       viewModelScope.launch {
-        val targetUid = friendId ?: profileRepo.getCurrentUserId()
-        if (targetUid != null) {
-          likesRepo.observeLikesCount(targetUid).collect { count ->
-            _uiState.value = _uiState.value.copy(likesCount = count)
+        val myUid = profileRepo.getCurrentUserId()
+        if (myUid != null) {
+          likesRepo.observeHasLiked(friendId, myUid).collect { liked ->
+            _uiState.value = _uiState.value.copy(hasLiked = liked)
           }
         }
       }
+    }
 
-      // Likes: only relevant when viewing a friend's garden
-      if (friendId != null) {
-        viewModelScope.launch {
-          val myUid = profileRepo.getCurrentUserId()
-          if (myUid != null) {
-            likesRepo.observeHasLiked(friendId, myUid).collect { liked ->
-              _uiState.value = _uiState.value.copy(hasLiked = liked)
-            }
-          }
-        }
-      }
-
-      // Only subscribe to plantsFlow if viewing own garden (not a friend's)
-      if (friendId == null) {
-        viewModelScope.launch {
-          plantsRepo.plantsFlow.collect { newList ->
-            _uiState.value = _uiState.value.copy(plants = newList)
-            applyFiltersAndSorting()
-          }
+    // Only subscribe to plantsFlow if viewing own garden (not a friend's)
+    if (friendId == null) {
+      viewModelScope.launch {
+        plantsRepo.plantsFlow.collect { newList ->
+          _uiState.value = _uiState.value.copy(plants = newList)
+          applyFiltersAndSorting()
         }
       }
     }

--- a/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
@@ -312,10 +312,14 @@ class GardenViewModel(
             setErrorMsg(R.string.error_failed_get_profile_garden)
           }
         } else {
-          val profile = profileRepo.getProfile().firstOrNull()
-          if (profile != null) {
-            _uiState.value =
-                _uiState.value.copy(userName = profile.pseudo, userAvatar = profile.avatar)
+          // Load own profile using ProfileRepository
+          profileRepo.getProfile().collect { profile ->
+            if (profile != null) {
+              _uiState.value =
+                  _uiState.value.copy(userName = profile.pseudo, userAvatar = profile.avatar)
+            } else {
+              setErrorMsg(R.string.error_failed_get_profile_garden)
+            }
           }
         }
       } catch (_: Exception) {

--- a/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
@@ -77,6 +77,8 @@ class GardenViewModel(
   /**
    * The value of the list now changes everytime it receives an update from the plants repository in
    * order to display the correct list of owned plants of the user
+   *
+   * It also updates the likeCount and hasLiked according to the like logic
    */
   init {
     refreshUIState()
@@ -131,6 +133,14 @@ class GardenViewModel(
     }
   }
 
+  /**
+   * Likes the currently viewed garden.
+   *
+   * This action is only allowed when viewing another user's garden. The operation is protected
+   * against multiple rapid clicks and is executed atomically through the likes repository.
+   *
+   * If the garden is already liked, clicking on the heart removes the like
+   */
   fun toggleLike() {
     if (friendId == null) return
 

--- a/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
@@ -85,9 +85,11 @@ class GardenViewModel(
 
     // Likes: observe count for the displayed garden (own or friend's)
     viewModelScope.launch {
-      val targetUid = friendId ?: profileRepo.getCurrentUserId()!!
-      likesRepo.observeLikesCount(targetUid).collect { count ->
-        _uiState.value = _uiState.value.copy(likesCount = count)
+      val targetUid = friendId ?: profileRepo.getCurrentUserId()
+      if (targetUid != null) {
+        likesRepo.observeLikesCount(targetUid).collect { count ->
+          _uiState.value = _uiState.value.copy(likesCount = count)
+        }
       }
     }
 

--- a/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/GardenViewModel.kt
@@ -312,14 +312,10 @@ class GardenViewModel(
             setErrorMsg(R.string.error_failed_get_profile_garden)
           }
         } else {
-          // Load own profile using ProfileRepository
-          profileRepo.getProfile().collect { profile ->
-            if (profile != null) {
-              _uiState.value =
-                  _uiState.value.copy(userName = profile.pseudo, userAvatar = profile.avatar)
-            } else {
-              setErrorMsg(R.string.error_failed_get_profile_garden)
-            }
+          val profile = profileRepo.getProfile().firstOrNull()
+          if (profile != null) {
+            _uiState.value =
+                _uiState.value.copy(userName = profile.pseudo, userAvatar = profile.avatar)
           }
         }
       } catch (_: Exception) {

--- a/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
@@ -59,6 +59,8 @@ import com.android.mygarden.ui.utils.handleOfflineClick
 object GardenAchievementsParentScreenTestTags {
   const val AVATAR_EDIT_PROFILE = "UserAvatarEditProfile"
   const val PSEUDO = "Pseudo"
+  const val LIKE_BUTTON = "LikeButton"
+  const val LIKE_COUNTER = "LikeCounter"
 
   fun getTestTagForTab(tab: GardenTab) = "${tab.titleRes}_Tab"
 }
@@ -378,7 +380,10 @@ fun LikeIndicator(
 ) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
-      modifier = modifier.then(if (enabled) Modifier.clickable { onLikeClick() } else Modifier)) {
+      modifier =
+          modifier
+              .testTag(GardenAchievementsParentScreenTestTags.LIKE_BUTTON)
+              .then(if (enabled) Modifier.clickable { onLikeClick() } else Modifier)) {
         Icon(
             imageVector = if (hasLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
             contentDescription = if (hasLiked) "Liked" else "Not liked",
@@ -393,6 +398,7 @@ fun LikeIndicator(
         Text(
             text = likesCount.toString(),
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface)
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.testTag(GardenAchievementsParentScreenTestTags.LIKE_COUNTER))
       }
 }

--- a/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
@@ -305,13 +305,13 @@ fun ProfileRow(
                   vertical = PROFILE_ROW_VERTICAL_PADDING),
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.SpaceBetween) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
           // Sign out button (hidden in view mode)
           if (!isViewMode) {
             NavigationButton(onClick = onSignOut, isSignOut = true)
+          } else {
+            Spacer(modifier = modifier.weight(FULL_WEIGHT))
           }
-          Spacer(modifier = modifier.weight(FULL_WEIGHT))
-
           // Username (user can click on it to edit profile)
           Text(
               modifier =

--- a/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
@@ -67,6 +67,7 @@ object GardenAchievementsParentScreenTestTags {
 
 // Padding constants
 private val PROFILE_ROW_HORIZONTAL_PADDING = 30.dp
+private val ICON_PADDING = 20.dp
 private val PROFILE_ROW_VERTICAL_PADDING = 6.dp
 private val COLUMN_VERTICAL_PADDING = 12.dp
 private val TAB_EXTERNAL_HORIZONTAL_PADDING = 16.dp
@@ -376,8 +377,9 @@ fun LikeIndicator(
     hasLiked: Boolean,
     enabled: Boolean,
     onLikeClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
+  val context = LocalContext.current
   Row(
       verticalAlignment = Alignment.CenterVertically,
       modifier =
@@ -386,14 +388,16 @@ fun LikeIndicator(
               .then(if (enabled) Modifier.clickable { onLikeClick() } else Modifier)) {
         Icon(
             imageVector = if (hasLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-            contentDescription = if (hasLiked) "Liked" else "Not liked",
+            contentDescription =
+                if (hasLiked) context.getString(R.string.description_liked)
+                else context.getString(R.string.description_not_liked),
             tint =
                 if (hasLiked) MaterialTheme.colorScheme.error
                 else if (enabled) MaterialTheme.colorScheme.primary
                 else MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(20.dp))
+            modifier = Modifier.size(ICON_PADDING))
 
-        Spacer(modifier = Modifier.size(6.dp))
+        Spacer(modifier = Modifier.size(PROFILE_ROW_VERTICAL_PADDING))
 
         Text(
             text = likesCount.toString(),

--- a/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
@@ -17,10 +17,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -137,6 +141,7 @@ fun ParentTabScreenGarden(
             gardenUiState = gardenUiState,
             isOnline = isOnline,
             isViewMode = isViewMode,
+            onLikeClick = { gardenViewModel.toggleLike() },
             modifier = modifier)
       },
       floatingActionButton = {
@@ -192,6 +197,7 @@ fun TopBarGardenParent(
     gardenUiState: GardenUIState,
     isOnline: Boolean,
     isViewMode: Boolean,
+    onLikeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
   CenterAlignedTopAppBar(
@@ -202,7 +208,8 @@ fun TopBarGardenParent(
             modifier,
             gardenUiState,
             isOnline,
-            isViewMode)
+            isViewMode,
+            onLikeClick)
       },
       navigationIcon = {
         if (isViewMode) {
@@ -273,6 +280,7 @@ fun TableRowGardenParent(
  * @param uiState the UI state
  * @param isOnline whether the device is online
  * @param isViewMode if true, hide the log out button (for viewing a friend's garden)
+ * @param onLikeClick if clicked toggle the like button
  */
 @Composable
 fun ProfileRow(
@@ -281,7 +289,8 @@ fun ProfileRow(
     modifier: Modifier = Modifier,
     uiState: GardenUIState,
     isOnline: Boolean,
-    isViewMode: Boolean = false
+    isViewMode: Boolean = false,
+    onLikeClick: () -> Unit
 ) {
   val context = LocalContext.current
 
@@ -319,6 +328,36 @@ fun ProfileRow(
               fontWeight = FontWeight.Bold,
               style = MaterialTheme.typography.titleLarge,
               text = uiState.userName)
+
+          Spacer(modifier = modifier.weight(FULL_WEIGHT))
+
+          // Like button
+          val likeEnabled = isViewMode && isOnline && !uiState.isLikeUpdating
+
+          Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier =
+                  Modifier.then(
+                      if (likeEnabled) Modifier.clickable { onLikeClick() } else Modifier)) {
+                Icon(
+                    imageVector =
+                        if (uiState.hasLiked) Icons.Filled.Favorite
+                        else Icons.Outlined.FavoriteBorder,
+                    contentDescription = if (uiState.hasLiked) "Liked" else "Not liked",
+                    tint =
+                        if (uiState.hasLiked) MaterialTheme.colorScheme.error
+                        else if (likeEnabled) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp))
+
+                Spacer(modifier = Modifier.size(6.dp))
+
+                Text(
+                    text = uiState.likesCount.toString(),
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface)
+              }
+
           Spacer(modifier = modifier.weight(FULL_WEIGHT))
 
           // User avatar (user can click on it to edit profile)

--- a/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
+++ b/app/src/main/java/com/android/mygarden/ui/garden/ParentTabScreenGarden.kt
@@ -334,29 +334,11 @@ fun ProfileRow(
           // Like button
           val likeEnabled = isViewMode && isOnline && !uiState.isLikeUpdating
 
-          Row(
-              verticalAlignment = Alignment.CenterVertically,
-              modifier =
-                  Modifier.then(
-                      if (likeEnabled) Modifier.clickable { onLikeClick() } else Modifier)) {
-                Icon(
-                    imageVector =
-                        if (uiState.hasLiked) Icons.Filled.Favorite
-                        else Icons.Outlined.FavoriteBorder,
-                    contentDescription = if (uiState.hasLiked) "Liked" else "Not liked",
-                    tint =
-                        if (uiState.hasLiked) MaterialTheme.colorScheme.error
-                        else if (likeEnabled) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp))
-
-                Spacer(modifier = Modifier.size(6.dp))
-
-                Text(
-                    text = uiState.likesCount.toString(),
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface)
-              }
+          LikeIndicator(
+              uiState.likesCount,
+              hasLiked = uiState.hasLiked,
+              enabled = likeEnabled,
+              onLikeClick = onLikeClick)
 
           Spacer(modifier = modifier.weight(FULL_WEIGHT))
 
@@ -383,5 +365,34 @@ fun ProfileRow(
                     modifier = modifier.fillMaxSize())
               }
         }
+      }
+}
+/** The composable used for the like display */
+@Composable
+fun LikeIndicator(
+    likesCount: Int,
+    hasLiked: Boolean,
+    enabled: Boolean,
+    onLikeClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = modifier.then(if (enabled) Modifier.clickable { onLikeClick() } else Modifier)) {
+        Icon(
+            imageVector = if (hasLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+            contentDescription = if (hasLiked) "Liked" else "Not liked",
+            tint =
+                if (hasLiked) MaterialTheme.colorScheme.error
+                else if (enabled) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp))
+
+        Spacer(modifier = Modifier.size(6.dp))
+
+        Text(
+            text = likesCount.toString(),
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface)
       }
 }

--- a/app/src/main/res/values/ui_strings.xml
+++ b/app/src/main/res/values/ui_strings.xml
@@ -65,6 +65,8 @@
     <string name="avatar_description">Avatar %1$s</string>
     <string name="error_fetch_all_plants_garden">getAllPlants failed : Owned plants couldn\'t be retrieved from repository</string>
     <string name="error_failed_get_profile_garden">Failed to get user profile</string>
+    <string name="description_liked">Liked</string>
+    <string name="description_not_liked">Not liked</string>
 
 
     <!-- Plant Info Screen -->

--- a/app/src/test/java/com/android/mygarden/ui/addFriend/AddFriendViewModelTest.kt
+++ b/app/src/test/java/com/android/mygarden/ui/addFriend/AddFriendViewModelTest.kt
@@ -239,11 +239,11 @@ class AddFriendViewModelTest {
     val dispatcher = StandardTestDispatcher(testScheduler)
     Dispatchers.setMain(dispatcher)
 
+    val fakeProfile = FakeProfileRepository()
     val fakeFriends = FakeFriendsRepository()
     val fakeRequests = FakeFriendRequestsRepository()
     val fakeUserProfile = FakeUserProfileRepository()
     val fakeAchievements = FakeAchievementsRepository()
-    val profileRepo = FakeProfileRepository()
     val fakePseudo =
         TestPseudoRepository().apply {
           searchResults = listOf("alice")
@@ -263,7 +263,7 @@ class AddFriendViewModelTest {
             requestsRepository = fakeRequests,
             userProfileRepository = fakeUserProfile,
             pseudoRepository = fakePseudo,
-            profileRepository = profileRepo,
+            profileRepository = fakeProfile,
             achievementsRepository = fakeAchievements)
 
     vm.onQueryChange("al")

--- a/app/src/test/java/com/android/mygarden/ui/feed/FeedNavigationTests.kt
+++ b/app/src/test/java/com/android/mygarden/ui/feed/FeedNavigationTests.kt
@@ -23,6 +23,7 @@ import com.android.mygarden.model.plant.PlantLocation
 import com.android.mygarden.model.plant.PlantsRepository
 import com.android.mygarden.model.plant.PlantsRepositoryLocal
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
+import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.model.profile.ProfileRepositoryProvider
 import com.android.mygarden.model.users.UserProfile
 import com.android.mygarden.model.users.UserProfileRepositoryProvider
@@ -137,6 +138,7 @@ class FeedNavigationTests {
       ProfileRepositoryProvider.repository = FakeProfileRepository()
       CareTipsRepositoryProvider.repository = FakeCareTipsRepository()
       AchievementsRepositoryProvider.repository = FakeAchievementsRepository()
+      LikesRepositoryProvider.repository = FakeLikesRepository()
 
       // initialize activities and plant
       runBlocking {

--- a/app/src/test/java/com/android/mygarden/ui/garden/GardenFilterSortScreenTests.kt
+++ b/app/src/test/java/com/android/mygarden/ui/garden/GardenFilterSortScreenTests.kt
@@ -11,6 +11,7 @@ import com.android.mygarden.model.gardenactivity.ActivityRepositoryProvider
 import com.android.mygarden.model.plant.PlantsRepositoryLocal
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
 import com.android.mygarden.model.profile.GardeningSkill
+import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.model.profile.Profile
 import com.android.mygarden.model.profile.ProfileRepository
 import com.android.mygarden.model.profile.ProfileRepositoryProvider
@@ -21,6 +22,7 @@ import com.android.mygarden.ui.navigation.Screen
 import com.android.mygarden.ui.profile.Avatar
 import com.android.mygarden.utils.FakeAchievementsRepository
 import com.android.mygarden.utils.FakeActivityRepository
+import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakeUserProfileRepository
 import com.android.mygarden.utils.TestPlants
 import java.sql.Timestamp
@@ -93,6 +95,7 @@ class GardenFilterSortScreenTests {
     UserProfileRepositoryProvider.repository = FakeUserProfileRepository()
     ActivityRepositoryProvider.repository = FakeActivityRepository()
     AchievementsRepositoryProvider.repository = FakeAchievementsRepository()
+    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Set up local plants repository for testing
     PlantsRepositoryProvider.repository = PlantsRepositoryLocal()

--- a/app/src/test/java/com/android/mygarden/ui/garden/GardenScreenOfflineTests.kt
+++ b/app/src/test/java/com/android/mygarden/ui/garden/GardenScreenOfflineTests.kt
@@ -13,6 +13,7 @@ import com.android.mygarden.model.plant.PlantsRepository
 import com.android.mygarden.model.plant.PlantsRepositoryLocal
 import com.android.mygarden.model.plant.PlantsRepositoryProvider
 import com.android.mygarden.model.profile.GardeningSkill
+import com.android.mygarden.model.profile.LikesRepositoryProvider
 import com.android.mygarden.model.profile.Profile
 import com.android.mygarden.model.profile.ProfileRepository
 import com.android.mygarden.model.profile.ProfileRepositoryProvider
@@ -21,6 +22,7 @@ import com.android.mygarden.ui.profile.Avatar
 import com.android.mygarden.ui.theme.MyGardenTheme
 import com.android.mygarden.utils.FakeAchievementsRepository
 import com.android.mygarden.utils.FakeActivityRepository
+import com.android.mygarden.utils.FakeLikesRepository
 import com.android.mygarden.utils.FakeProfileRepository
 import com.android.mygarden.utils.FakeUserProfileRepository
 import com.android.mygarden.utils.TestPlants
@@ -80,6 +82,7 @@ class GardenScreenOfflineTests {
     ActivityRepositoryProvider.repository = activityRepo
     UserProfileRepositoryProvider.repository = FakeUserProfileRepository()
     AchievementsRepositoryProvider.repository = FakeAchievementsRepository()
+    LikesRepositoryProvider.repository = FakeLikesRepository()
 
     // Ensure we start with online state
     OfflineStateManager.setOnlineState(true)

--- a/app/src/test/java/com/android/mygarden/utils/FakeLikesRepository.kt
+++ b/app/src/test/java/com/android/mygarden/utils/FakeLikesRepository.kt
@@ -5,20 +5,31 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeLikesRepository : LikesRepository {
-  private val counts = mutableMapOf<String, MutableStateFlow<Int>>()
-  private val liked = mutableSetOf<Pair<String, String>>() // (targetUid, myUid)
+  private val likesCounts = mutableMapOf<String, MutableStateFlow<Int>>()
+  private val likedPairs = mutableSetOf<Pair<String, String>>() // (targetUid, myUid)
+  private val hasLikedFlows = mutableMapOf<Pair<String, String>, MutableStateFlow<Boolean>>()
 
   override fun observeLikesCount(targetUid: String): Flow<Int> =
-      counts.getOrPut(targetUid) { MutableStateFlow(0) }
+      likesCounts.getOrPut(targetUid) { MutableStateFlow(0) }
 
   override fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean> =
-      MutableStateFlow(liked.contains(targetUid to myUid))
+      hasLikedFlows.getOrPut(targetUid to myUid) {
+        MutableStateFlow(likedPairs.contains(targetUid to myUid))
+      }
 
   override suspend fun toggleLike(targetUid: String, myUid: String) {
     val key = targetUid to myUid
-    if (liked.add(key)) {
-      val flow = counts.getOrPut(targetUid) { MutableStateFlow(0) }
-      flow.value = flow.value + 1
+    val already = likedPairs.contains(key)
+    if (!already) {
+      likedPairs.add(key)
+      likesCounts.getOrPut(targetUid) { MutableStateFlow(0) }.value += 1
+      hasLikedFlows.getOrPut(key) { MutableStateFlow(false) }.value = true
+    } else {
+      // simulate "toggle off"
+      likedPairs.remove(key)
+      likesCounts.getOrPut(targetUid) { MutableStateFlow(0) }.value =
+          maxOf(0, likesCounts.getOrPut(targetUid) { MutableStateFlow(0) }.value - 1)
+      hasLikedFlows.getOrPut(key) { MutableStateFlow(true) }.value = false
     }
   }
 }

--- a/app/src/test/java/com/android/mygarden/utils/FakeLikesRepository.kt
+++ b/app/src/test/java/com/android/mygarden/utils/FakeLikesRepository.kt
@@ -1,0 +1,24 @@
+package com.android.mygarden.utils
+
+import com.android.mygarden.model.profile.LikesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeLikesRepository : LikesRepository {
+  private val counts = mutableMapOf<String, MutableStateFlow<Int>>()
+  private val liked = mutableSetOf<Pair<String, String>>() // (targetUid, myUid)
+
+  override fun observeLikesCount(targetUid: String): Flow<Int> =
+      counts.getOrPut(targetUid) { MutableStateFlow(0) }
+
+  override fun observeHasLiked(targetUid: String, myUid: String): Flow<Boolean> =
+      MutableStateFlow(liked.contains(targetUid to myUid))
+
+  override suspend fun toggleLike(targetUid: String, myUid: String) {
+    val key = targetUid to myUid
+    if (liked.add(key)) {
+      val flow = counts.getOrPut(targetUid) { MutableStateFlow(0) }
+      flow.value = flow.value + 1
+    }
+  }
+}


### PR DESCRIPTION
## What ?

Add a like feature to user gardens.
Users can like other users’ gardens, see the total number of likes, and toggle their like. The like state is reflected in the UI with a heart icon in the garden top bar.

## Why ?

This feature increases social interaction and engagement by allowing users to appreciate other gardens.

## How ?
	•	Introduced a LikesRepository with a Firestore implementation storing likes per user.
	•	Added like state (likesCount, hasLiked, isLikeUpdating) to GardenViewModel.
	•	Observed likes count and like status via flows to keep the UI reactive.
	•	Added a reusable LikeIndicator composable in the garden top bar.
	•	Provided fake repositories for tests and updated providers accordingly.

## Testing ?
	•	Added unit tests for LikesRepositoryFirestore.
	•	Added ViewModel tests covering like toggling and UI state updates.
	•	Added UI tests for the garden screen to verify like visibility, clickability, and counter updates.
	•	Updated existing tests to inject fake likes repositories and ensure stability.

this description was made with the help of an ia