### PR TITLE
test(e2e): add EndToEndM3Community test

### DIFF
--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM3Community.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM3Community.kt
@@ -39,7 +39,6 @@ import com.android.mygarden.utils.FirebaseUtils
 import com.android.mygarden.utils.RequiresCamera
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -88,7 +87,7 @@ class EndToEndM3Community {
   val permissionNotifsRule: GrantPermissionRule =
       GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
 
-  private val TIMEOUT = 10_000L
+  private val TIMEOUT = 15_000L
 
   private val firebaseUtils: FirebaseUtils = FirebaseUtils()
   private lateinit var mainUserAliceUid: String
@@ -132,10 +131,8 @@ class EndToEndM3Community {
             .assertIsDisplayed()
             .performClick()
 
-        runBlocking {
-          firebaseUtils.signIn()
-          firebaseUtils.waitForAuthReady()
-        }
+        firebaseUtils.signIn()
+        firebaseUtils.waitForAuthReady()
         mainUserAliceUid = firebaseUtils.auth.uid!!
 
         // === CREATE MAIN USER PROFILE ===
@@ -181,12 +178,10 @@ class EndToEndM3Community {
             .onNodeWithTag(SignInScreenTestTags.SIGN_IN_SCREEN_GOOGLE_BUTTON)
             .performClick()
 
-        runBlocking {
-          friendFirebaseUtils.signIn()
-          friendFirebaseUtils.waitForAuthReady()
-        }
+        friendFirebaseUtils.signIn()
+        friendFirebaseUtils.waitForAuthReady()
 
-        friendUserBobUid = firebaseUtils.auth.uid!!
+        friendUserBobUid = friendFirebaseUtils.auth.uid!!
 
         // === CREATE FRIEND USER PROFILE ===
         composeTestRule.waitUntil(TIMEOUT) {


### PR DESCRIPTION
# Improve Community Navigation Coverage with End-to-End Test

## What  
This PR adds a **new end-to-end (E2E) UI test** focused on the **Community epic**.  

### Android
- Added a full **Compose E2E test** covering the Community user journey:
  - Feed navigation
  - Friend request flow (send + accept)
  - Friend list
  - Friend garden
  - Friend achievements
  - Friend plant info
  - Back navigation across multiple screens

---

## Why  
The Community epic relies heavily on **navigation between screens**, this test is to simulate a full journey of a user that adds a friends and wants to see his garden.  

This PR:
- Strengthens confidence in the **end-to-end Community workflow**
- Covers real user navigation paths instead of isolated screens
- Improves **navigation and screen-transition coverage**
- Complements the E2E test added previously.  

---

## How  
- Added a new **end-to-end Compose test** simulating two real users:
  - **Alice** (main user)
  - **Bob** (friend)

### Tested Flow (Community Epic)
1. Go to the **Feed**
2. Send a **friend request**
3. Accept the **friend request**
4. Open the **friend list**
5. Navigate to a **friend’s garden**
6. Open **friend’s achievements**
7. Open **friend’s plant info**
8. Navigate back through screens
9. Return to the **Feed**
10. Verify the friend’s activity appears in the feed

The test exercises:
- `NavHost`
- Back stack handling
- Conditional UI (own vs friend views)
- Read-only vs editable screens

---

## Tests  
- **New E2E test:** `EndToEndM3Community`
- Covers authentication, profile creation, friend requests, and full Community navigation
- Uses real repositories and navigation paths
- Assertions verify each screen transition

---

## Impact on Coverage  
- **Improves NavHost line coverage**, especially for:
  - Feed → Friend Requests
  - Feed → Friend List
  - Friend List → Friend Garden
  - Garden ↔ Achievements
  - Garden → Plant Info
  - Back navigation handling

These paths were previously **partially or not covered** by existing tests.

---

## Notes  
- The test is intentionally **long-running and stateful** to reflect a real multi-user scenario
- Uses the `mygarden.e2e` system flag to isolate E2E behavior
- Camera and notification permissions are explicitly granted for stability

---

[PR description generated with help of an AI agent]
