### PR TITLE
test(e2e): add EndToEndM3Achievments test

### DIFF
--- a/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM3Achievements.kt
+++ b/app/src/androidTest/java/com/android/mygarden/zEndToEnd/EndToEndM3Achievements.kt
@@ -79,7 +79,9 @@ class EndToEndM3Achievements {
   val permissionNotifsRule: GrantPermissionRule =
       GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
 
+  private val GENERAL_TIMEOUT = 200_000.milliseconds
   private val TIMEOUT = 15_000L
+  private val THREAD_SLEEP_TIME = 2000L
 
   private val bobFirebaseUtils: FirebaseUtils = FirebaseUtils()
   private lateinit var bobUserUid: String
@@ -120,7 +122,7 @@ class EndToEndM3Achievements {
 
   @Test
   fun test_end_to_end_m3_achievements() =
-      runTest(timeout = 200_000.milliseconds) {
+      runTest(timeout = GENERAL_TIMEOUT) {
         // === STEP 1: SIGN IN AS BOB AND CREATE PROFILE ===
         Log.d("EndToEndM3Achievements", "Step 1: Sign in as Bob")
         composeTestRule
@@ -128,10 +130,8 @@ class EndToEndM3Achievements {
             .assertIsDisplayed()
             .performClick()
 
-        // runBlocking {
         bobFirebaseUtils.signIn()
         bobFirebaseUtils.waitForAuthReady()
-        // }
         bobUserUid = bobFirebaseUtils.auth.uid!!
 
         // Create Bob's profile
@@ -323,10 +323,8 @@ class EndToEndM3Achievements {
             .onNodeWithTag(SignInScreenTestTags.SIGN_IN_SCREEN_GOOGLE_BUTTON)
             .performClick()
 
-        // runBlocking {
         aliceFirebaseUtils.signIn()
         aliceFirebaseUtils.waitForAuthReady()
-        // }
         aliceUserUid = aliceFirebaseUtils.auth.uid!!
 
         // Create Alice's profile
@@ -452,7 +450,8 @@ class EndToEndM3Achievements {
         // Wait for the friend request to be fully processed and achievements to be updated
         composeTestRule.waitForIdle()
         Thread.sleep(
-            2000) // Give Firebase time to process the friend addition and achievement update
+            THREAD_SLEEP_TIME) // Give Firebase time to process the friend addition and achievement
+        // update
 
         Log.d("EndToEndM3Achievements", "Bob accepted Alice's friend request")
 


### PR DESCRIPTION
# Add End-to-End Test for Garden & Achievements Progression

## What  
This PR adds a **new end-to-end (E2E) UI test** covering **Garden progression and Achievements validation** across multiple users.

### Android
- Added a **Compose E2E test** covering:
  - Profile creation
  - Garden population
  - Achievements progression
  - Friend request flow
  - Friends achievement validation

---

## Why  
Achievements rely on **state built across multiple features** (Garden, Profile, Community).  
This test validates that achievement levels are:
- Correctly updated
- Persisted across sessions
- Reflected after social interactions

This strengthens confidence in **end-to-end achievements behavior** and complements existing Community E2E coverage.

---

## How  
- Added a **Compose E2E test** simulating two users:
  - **Bob** (primary user)
  - **Alice** (secondary user)

### Tested Flow
1. Sign in as **Bob** and create his profile  
2. Add **3 plants** to Bob’s garden  
3. Verify **Plants achievement → Level 3 / 10**  
4. Sign in as **Alice**, create her profile, and send a friend request to Bob  
5. Sign back in as **Bob**, accept the request  
6. Verify **Friends achievement → Level 2 / 10**

---

## Tests  
- **New E2E test:** `EndToEndM3Achievements`
- Uses real repositories, navigation, and assertions on achievement levels

---

## Impact on Coverage  
- Improves coverage for:
  - Garden → Achievements linkage
  - Achievement level calculation
  - Friend-based achievements
  - State persistence across sign-in / sign-out

---

[PR description generated with help of an AI agent]
